### PR TITLE
Fixes self-referencing alias prevention.

### DIFF
--- a/src/Gambot.Module.Factoid/AddFactoidCommand.cs
+++ b/src/Gambot.Module.Factoid/AddFactoidCommand.cs
@@ -29,7 +29,7 @@ namespace Gambot.Module.Factoid
             var verb = match.Groups[2].Value.ToLowerInvariant();
             var response = match.Groups[3].Value;
 
-            if (verb == "alias" && String.Compare(trigger, response, true) == 0)
+            if (verb == "<alias>" && String.Compare(trigger, response, true) == 0)
                 return message.Respond($"Sorry, {message.From.Mention}, but you can't alias {trigger} to itself.");
 
             var added = await dataStore.Add(trigger, $"{verb} {response}");


### PR DESCRIPTION
It appears that AddFactoidCommand was checking if the verb was "alias", rather than "<alias>".