### PR TITLE
Adds the ability to specify an optional % to proc to factoids.

### DIFF
--- a/src/Gambot.Module.Factoid/AddFactoidCommand.cs
+++ b/src/Gambot.Module.Factoid/AddFactoidCommand.cs
@@ -27,6 +27,18 @@ namespace Gambot.Module.Factoid
 
             var trigger = match.Groups[1].Value.ToLowerInvariant();
             var verb = match.Groups[2].Value.ToLowerInvariant();
+
+            var percentMatch = Regex.Match(verb, @"\|(?!.*\|)(.*?)%>$");
+            if (percentMatch.Success)
+            {
+                decimal chanceToTrigger;
+                if (!Decimal.TryParse(percentMatch.Groups[1].Value, out chanceToTrigger))
+                    return message.Respond($"Sorry, {message.From.Mention}, but {verb} is not properly formatted.");
+
+                if (chanceToTrigger <= 0 || chanceToTrigger > 100)
+                    return message.Respond($"Sorry, {message.From.Mention}, but {verb} does not contain a valid percentage.");
+            }
+
             var response = match.Groups[3].Value;
 
             if (verb == "<alias>" && String.Compare(trigger, response, true) == 0)

--- a/src/Gambot.Module.Factoid/Factoid.cs
+++ b/src/Gambot.Module.Factoid/Factoid.cs
@@ -5,7 +5,7 @@ namespace Gambot.Module.Factoid
         public string Trigger { get; set; }
         public string Verb { get; set; }
         public string Response { get; set; }
-
-        public override string ToString() => $"{Trigger} <{Verb}> {Response}";
+        public decimal ChanceToTrigger { get; set; }
+        public override string ToString() => $"{Trigger} <{Verb}|{ChanceToTrigger}%> {Response}";
     }
 }


### PR DESCRIPTION
Example:
```
gambot, test <reply|50%> hello
```

This update is backwards compatible.

Random quirks because of implementation:
- You can store any decimal percentage (e.g. `<verb|0.0005%>`), but because "chance" is implemented with a random number between 0 and 100, decimals effectively have no effect. 🤷🏽 
- Valid percentages are in the range of (0, 100]; I wanted to avoid implicit behavior (e.g. flooring the percentage with 100, or ceiling it with 0). Let me know if the implicit behavior would be preferred.